### PR TITLE
Add missing argument to command-line invocation

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -352,7 +352,7 @@ if __name__ == '__main__':
         '', 'nonbinary', 'men', 'women', 'unknown'))
 
     for user_type, users in [
-        ('friends', analyze_friends(user_id, consumer_key, consumer_secret,
+        ('friends', analyze_friends(user_id, None, consumer_key, consumer_secret,
                                     tok, tok_secret)),
         ('followers', analyze_followers(user_id, consumer_key, consumer_secret,
                                         tok, tok_secret)),


### PR DESCRIPTION
Commit 431f19fe56 added an extra parameter to `analyze_friends()`, but didn’t add a matching argument to the invocation in command-line mode. Since I don’t know what the extra argument does, I’m going for the simplest possible solution, which is to just specify `None` for the extra argument (`analyze_friends()` explicitly checks whether the `list_id` is `None`, so presumably that’s a valid argument). Fixes #16.