### PR TITLE
Edited deauthorize link

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -138,7 +138,7 @@ td.td-first-col {
 
     {% if session.get('twitter_user') %}
       <h4>Hello, @{{ session.twitter_user }}.</h4>
-      <p><a href="/logout">Deauthorize this application with Twitter.</a></p>
+	    <p><a href="/logout">Logout</a>. To deauthorize this application with Twitter, visit <a href="https://twitter.com/settings/sessions">Your App Settings</a>.</p>
       <hr>
       <form method="post" onsubmit="return analyze_click()">
         <div class="form-group">


### PR DESCRIPTION
Changed link that removes cookie to "log out" and provided link to Twitter to actually deauthorize the app. You may have a better idea for phrasing and aesthetics, but it seems like the link's behavior dosent't quite mesh with the text as it doesn't actually deauthorize the app. 